### PR TITLE
created qr code generation code, waiting on #6 to embed in email

### DIFF
--- a/app/server/services/qr-generator.js
+++ b/app/server/services/qr-generator.js
@@ -1,0 +1,52 @@
+var qr = require('qr-image');
+var fs = require('fs');
+
+controller = {};
+
+/**
+ * Generate a image file in the directory, containing the payload.
+ * Mainly for testing purposes; possible file types include png, svg, pdf, and eps.
+ * @param   {[type]}    payload     [description]
+ * @param   {[type]}    fileName    [description]
+ * @param   {[type]}    fileType    [description]
+ * @param   {Function}  callback    [description]
+ */
+function generateQrCodeFile(payload, fileName, fileType, callback) {
+    var qr_svg = qr.image(JSON.stringify(payload), { type: fileType });
+    qr_svg.pipe(fs.createWriteStream(fileName+'.'+fileType));
+}
+
+
+/**
+ * Generate a string with QR image data, containing the payload.
+ * @param   {[type]}    payload     [description]
+ * @param   {Function}  callback    [description]
+ */
+function generateQrCodeString(payload, callback) {
+    var qr_string = qr.imageSync(JSON.stringify(payload));
+    return qr_string;
+}
+
+/**
+ * Generate a QR code compatible with Cumin that contains:
+ * user's name, age, birthday, email and school
+ * @param   {[type]}    name        [description]
+ * @param   {[type]}    age         [description]
+ * @param   {[type]}    birthday    [description]
+ * @param   {[type]}    school      [description]
+ * @param   {Function}  callback    [description]
+ * @return  {[type]}                [description]
+ */
+controller.generateCheckInCode = function (name, age, birthday, email, school, callback) {
+    var payload = {
+        "name": name,
+        "email": email,
+        "age": age,
+        "birthday": birthday,
+        "school": school
+    }
+    var qr_string = generateQrCodeString(payload);
+    return qr_string;
+}
+
+module.exports = controller;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dotenv": "^1.2.0",
     "email-templates": "^2.0.1",
     "express": "^4.9.8",
+    "fs": "0.0.1-security",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.1",
     "gulp-minify-css": "^1.2.0",
@@ -27,6 +28,7 @@
     "mongoose": "^4.1.2",
     "morgan": "^1.6.1",
     "passport-local": "^1.0.0",
+    "qr-image": "^3.2.0",
     "request": "^2.60.0",
     "underscore": "^1.8.3",
     "validator": "^3.40.1"


### PR DESCRIPTION
## TODO:
- send confirmation email in quill with qr code and integrate cumin check in

This commit contains code to generate QR strings (default behavior) and QR code image files. 

William and I discussed what we thought Quill needed to send to Cumin so that's already implemented in this commit (Quill currently embeds the confirmed hacker's name, age, birthday, email, and school). 

Was unable to embed into confirmation email part as confirmation emails are unimplemented.